### PR TITLE
Fix rerouting no user

### DIFF
--- a/components/AuthCheck/index.js
+++ b/components/AuthCheck/index.js
@@ -8,7 +8,6 @@ export default function AuthCheck(props) {
     const { user, loading } = useContext(UserContext);
     const router = useRouter(); // Router Initialization to prepare for imperative navigation if not logged in
     
-    console.log({user, loading})
     useEffect(() => {
       if (!user & !loading) {
         router.push('/enter')

--- a/components/AuthCheck/index.js
+++ b/components/AuthCheck/index.js
@@ -7,12 +7,13 @@ import { auth } from "../../lib/firebase"
 export default function AuthCheck(props) {
     const { user, loading } = useContext(UserContext);
     const router = useRouter(); // Router Initialization to prepare for imperative navigation if not logged in
-        
+    
+    console.log({user, loading})
     useEffect(() => {
-        if (!user & !loading) {
-          router.push('/enter')
-        }
-      }, [user])
+      if (!user & !loading) {
+        router.push('/enter')
+      }
+    }, [user, loading])
 
     return user ? props.children : props.fallback || <Link href="/enter"><a>You must be signed in.</a></Link>
 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -9,7 +9,7 @@ export function useUserData() {
     // input not available at loading time (i.e. user state)
     const [loadNotifications, setLoadNotifications] = useState(true)
     const [emailNotification, setEmailNotifications] = useState(null);
-  
+    
     useEffect(() => {
       // variable to turn of real-time subscription
       let unsubscribe;
@@ -26,7 +26,7 @@ export function useUserData() {
       }
   
       return unsubscribe;
-    }, [user])
+    }, [user, loading])
 
     return { user, loading, error, emailNotification, loadNotifications };
 }

--- a/pages/enter.js
+++ b/pages/enter.js
@@ -20,7 +20,7 @@ function Alert(props) {
 }
 
 export default function SignInPage(props) {
-    const [user] = useAuthState(auth);
+    const [user, loading] = useAuthState(auth);
     const router = useRouter(); // Router Initialization to prepare for imperative navigation if not logged in
     
     const classes = useStyles();
@@ -30,7 +30,7 @@ export default function SignInPage(props) {
         if (user) {
           router.push('/')
         }
-    }, [user])
+    }, [user, loading])
     
     return (
         <>


### PR DESCRIPTION
useEffect in <AuthCheck>, <SignInPage> and CustomHooks required `loading` variable to be added as a dependency to function properly.